### PR TITLE
Fix loading bundle by identifier

### DIFF
--- a/Classes/YTPlayerView.m
+++ b/Classes/YTPlayerView.m
@@ -873,10 +873,15 @@ NSString static *const kYTPlayerSyndicationRegexPattern = @"^https://tpc.googles
 
 + (NSBundle *)assetsBundle {
     static NSBundle* assetsBundle = nil;
-    
+
     static dispatch_once_t predicate;
     dispatch_once(&predicate, ^{
-        NSBundle *frameworkBundle = [NSBundle bundleWithIdentifier:@"org.cocoapods.youtube-ios-player-helper"];
+        NSBundle *frameworkBundle = [NSBundle bundleWithIdentifier:@"com.youtube.youtube-ios-player-helper"];
+        if (!frameworkBundle) {
+            // The identifier is different in case the framework is installed via Cocoapods
+            frameworkBundle = [NSBundle bundleWithIdentifier:@"org.cocoapods.youtube-ios-player-helper"];
+        }
+
         NSString *assetsBundlePath = [frameworkBundle pathForResource:@"Assets" ofType:@"bundle"];
         assetsBundle = [NSBundle bundleWithPath:assetsBundlePath];
     });


### PR DESCRIPTION
This PR is an improvement for #1.

The original PR fixed the problem only for Cocoapods, this one should work properly in all cases, no matter how the framework is used.